### PR TITLE
TASK: Reset Bootstrap::$staticObjectManager after functional test

### DIFF
--- a/Tests/Functional/ThrowableStorage/CompoundStorageTest.php
+++ b/Tests/Functional/ThrowableStorage/CompoundStorageTest.php
@@ -84,14 +84,19 @@ class CompoundStorageTest extends FunctionalTestCase
             ]
         ]);
 
+        self::expectException(Test::class);
+        self::expectExceptionCode(1);
+
+        $staticObjectManager = Bootstrap::$staticObjectManager;
         Bootstrap::$staticObjectManager = null;
 
         $throwable = new Test('foo', 1);
 
-        self::expectException(Test::class);
-        self::expectExceptionCode(1);
-
-        $storage->logThrowable($throwable);
+        try {
+            $storage->logThrowable($throwable);
+        } finally {
+            Bootstrap::$staticObjectManager = $staticObjectManager;
+        }
     }
 
 }


### PR DESCRIPTION
PHPUnit does not reset this public static property automatically,
which means it will be null for every upcomming test. This leads
to exceptions in FunctionalTestCase::setupBeforeClass() for every
upcomming tests, regardless of the actual test code.