### PR TITLE
BUGFIX: Require flow/behat:@dev instead of dev-master in test

### DIFF
--- a/.github/workflows/functionaltests.yml
+++ b/.github/workflows/functionaltests.yml
@@ -29,7 +29,7 @@ jobs:
           extensions: mbstring, xml, json, zlib, iconv, intl, pdo_sqlite
           ini-values: opcache.fast_shutdown=0
 
-      - name: Cache composer dependencies
+      - name: "[1/4] Create composer project - Cache composer dependencies"
         uses: actions/cache@v1
         with:
           path: ~/.composer/cache
@@ -37,8 +37,17 @@ jobs:
           restore-keys: |
             php-${{ matrix.php-version }}-flow-${{ matrix.flow-version }}-composer-
             php-${{ matrix.php-version }}-flow-
-      - name: Install composer dependencies
-        run: composer create-project neos/flow-base-distribution ${{ env.FLOW_DIST_FOLDER }} --prefer-dist --no-progress "^${{ matrix.flow-version }}"
+
+      - name: "[2/4] Create composer project - No install"
+        run: composer create-project neos/flow-base-distribution ${{ env.FLOW_DIST_FOLDER }} --prefer-dist --no-progress --no-install "^${{ matrix.flow-version }}"
+
+      - name: "[3/4] Create composer project  - Require behat in compatible version"
+        run: composer require --dev --no-update "neos/behat:@dev"
+        working-directory: ${{ env.FLOW_DIST_FOLDER }}
+
+      - name: "[4/4] Create composer project - Install project"
+        run: composer install
+        working-directory: ${{ env.FLOW_DIST_FOLDER }}
 
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -29,7 +29,7 @@ jobs:
           extensions: mbstring, xml, json, zlib, iconv, intl, pdo_sqlite
           ini-values: opcache.fast_shutdown=0
 
-      - name: Cache composer dependencies
+      - name: "[1/4] Create composer project - Cache composer dependencies"
         uses: actions/cache@v1
         with:
           path: ~/.composer/cache
@@ -37,8 +37,17 @@ jobs:
           restore-keys: |
             php-${{ matrix.php-version }}-flow-${{ matrix.flow-version }}-composer-
             php-${{ matrix.php-version }}-flow-
-      - name: Install composer dependencies
-        run: composer create-project neos/flow-base-distribution ${{ env.FLOW_DIST_FOLDER }} --prefer-dist --no-progress "^${{ matrix.flow-version }}"
+
+      - name: "[2/4] Create composer project - No install"
+        run: composer create-project neos/flow-base-distribution ${{ env.FLOW_DIST_FOLDER }} --prefer-dist --no-progress --no-install "^${{ matrix.flow-version }}"
+
+      - name: "[3/4] Create composer project  - Require behat in compatible version"
+        run: composer require --dev --no-update "neos/behat:@dev"
+        working-directory: ${{ env.FLOW_DIST_FOLDER }}
+
+      - name: "[4/4] Create composer project - Install project"
+        run: composer install
+        working-directory: ${{ env.FLOW_DIST_FOLDER }}
 
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
The regular neos/flow-base-distribution depends on dev-master of
neos/behat, which is not compatible with flow 5.3 and 6.3. Using
@dev allows composer to detect a proper version.