### PR TITLE
FEATURE: Allow mapping of renderingGroup by Exception Code

### DIFF
--- a/Classes/ExceptionHandler/ExceptionRenderingOptionsResolver.php
+++ b/Classes/ExceptionHandler/ExceptionRenderingOptionsResolver.php
@@ -25,6 +25,25 @@ final class ExceptionRenderingOptionsResolver extends AbstractExceptionHandler
         return $this->resolveCustomRenderingOptions($throwable);
     }
 
+    protected function resolveRenderingGroup(\Throwable $exception)
+    {
+        $renderingGroup = parent::resolveRenderingGroup($exception);
+        if ($renderingGroup === null) {
+            // try to match using exception code
+            foreach ($this->options['renderingGroups'] as $renderingGroupName => $renderingGroupSettings) {
+                if (isset($renderingGroupSettings['matchingExceptionCodes'])) {
+                    foreach ($renderingGroupSettings['matchingExceptionCodes'] as $exceptionCode) {
+                        if ($exception->getCode() === $exceptionCode) {
+                            return $renderingGroupName;
+                        }
+                    }
+                }
+            }
+        }
+
+        return $renderingGroup;
+    }
+
     /**
      * @param Throwable $exception
      * @internal

--- a/Classes/ExceptionHandler/ExceptionRenderingOptionsResolver.php
+++ b/Classes/ExceptionHandler/ExceptionRenderingOptionsResolver.php
@@ -27,6 +27,9 @@ final class ExceptionRenderingOptionsResolver extends AbstractExceptionHandler
 
     protected function resolveRenderingGroup(\Throwable $exception)
     {
+        if (!isset($this->options['renderingGroups'])) {
+            return null;
+        }
         $renderingGroup = parent::resolveRenderingGroup($exception);
         if ($renderingGroup === null) {
             // try to match using exception code

--- a/Classes/ExceptionHandler/ExceptionRenderingOptionsResolver.php
+++ b/Classes/ExceptionHandler/ExceptionRenderingOptionsResolver.php
@@ -15,6 +15,12 @@ use Throwable;
 final class ExceptionRenderingOptionsResolver extends AbstractExceptionHandler
 {
 
+    /**
+     * @var array
+     * @Flow\InjectConfiguration(package="Neos.Flow", path="error.exceptionHandler")
+     */
+    protected $options;
+
     /** @noinspection PhpMissingParentConstructorInspection */
     public function __construct()
     {

--- a/README.md
+++ b/README.md
@@ -189,6 +189,9 @@ Neos:
           ignoredExceptions:
             matchingStatusCodes: [ 418 ]
             matchingExceptionClassNames: [ 'Your\Ignored\Exception' ]
+            # It is also possible to match against \Throwable::getCode(). Please note that this is not a Flow feature.
+            # Check \Netlogix\Sentry\ExceptionHandler\ExceptionRenderingOptionsResolver::resolveRenderingGroup() for more info
+            # matchingExceptionCodes: [1638880375]
             options:
               logException: false
 ```

--- a/Tests/Unit/ExceptionHandler/ExceptionRenderingOptionsResolverTest.php
+++ b/Tests/Unit/ExceptionHandler/ExceptionRenderingOptionsResolverTest.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+namespace Netlogix\Sentry\Tests\Unit\ExceptionHandler;
+
+use Neos\Flow\Tests\UnitTestCase;
+use Netlogix\Sentry\ExceptionHandler\ExceptionRenderingOptionsResolver;
+
+class ExceptionRenderingOptionsResolverTest extends UnitTestCase
+{
+
+    /**
+     * @test
+     */
+    public function If_no_renderingGroups_have_been_defined_an_empty_array_is_returned(): void
+    {
+        $resolver = new ExceptionRenderingOptionsResolver();
+
+        $result = $resolver->resolveRenderingOptionsForThrowable(self::createThrowable());
+
+        self::assertEmpty($result);
+    }
+
+    /**
+     * @test
+     */
+    public function Exception_Code_is_used_to_match_rendering_Groups(): void
+    {
+        $resolver = new ExceptionRenderingOptionsResolver();
+
+        $resolver->setOptions([
+            'renderingGroups' => [
+                'someGroup' => [
+                    'matchingExceptionCodes' => [self::code()],
+                    'options' => [
+                        'foo' => 'bar'
+                    ]
+                ]
+            ]
+        ]);
+
+        $result = $resolver->resolveRenderingOptionsForThrowable(self::createThrowable());
+
+        self::assertArrayHasKey('renderingGroup', $result);
+        self::assertEquals('someGroup', $result['renderingGroup']);
+
+        self::assertArrayHasKey('foo', $result);
+        self::assertEquals('bar', $result['foo']);
+    }
+
+    private static function createThrowable(): \Throwable
+    {
+        return new \Exception('foo', self::code());
+    }
+
+    private static function code(): int
+    {
+        return 1638882641;
+    }
+
+}


### PR DESCRIPTION
By default it's only possible to match renderingGroups of exceptions against className and statusCode. When an external library uses the same Exception class for all exceptions (e.g. Flowpack.JobQueue.Common), it is not possible to disable logging for specific exceptions.

