### PR TITLE
TASK: Drop support for Flow 5 & 6

### DIFF
--- a/.github/workflows/functionaltests.yml
+++ b/.github/workflows/functionaltests.yml
@@ -10,26 +10,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ 7.2, 7.3, 7.4, 8.0, 8.1 ]
-        flow-version: [ 5.3, 6.3, 7.3, 8.0 ]
+        php-version: [ 7.3, 7.4, 8.0, 8.1 ]
+        flow-version: [ 7.3, 8.0 ]
         exclude:
-          # Disable Flow 5.3 and 6.3 on PHP 8.0, as only ^7.2 is supported
-          - php-version: 8.0
-            flow-version: 5.3
-          - php-version: 8.0
-            flow-version: 6.3
-          - php-version: 8.1
-            flow-version: 5.3
-          - php-version: 8.1
-            flow-version: 6.3
-
-          # Disable Flow 7.0 on PHP 7.2, as 7.3 is required
-          - php-version: 7.2
-            flow-version: 7.3
-
           # Disable Flow 8.0 on PHP 7, as 8.0 is required
-          - php-version: 7.2
-            flow-version: 8.0
           - php-version: 7.3
             flow-version: 8.0
           - php-version: 7.4

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -10,26 +10,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ 7.2, 7.3, 7.4, 8.0, 8.1 ]
-        flow-version: [ 5.3, 6.3, 7.3, 8.0 ]
+        php-version: [ 7.3, 7.4, 8.0, 8.1 ]
+        flow-version: [ 7.3, 8.0 ]
         exclude:
-          # Disable Flow 5.3 and 6.3 on PHP 8.0, as only ^7.2 is supported
-          - php-version: 8.0
-            flow-version: 5.3
-          - php-version: 8.0
-            flow-version: 6.3
-          - php-version: 8.1
-            flow-version: 5.3
-          - php-version: 8.1
-            flow-version: 6.3
-
-          # Disable Flow 7.0 on PHP 7.2, as 7.3 is required
-          - php-version: 7.2
-            flow-version: 7.3
-
           # Disable Flow 8.0 on PHP 7, as 8.0 is required
-          - php-version: 7.2
-            flow-version: 8.0
           - php-version: 7.3
             flow-version: 8.0
           - php-version: 7.4

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ fit your needs.
 
 Currently the following Flow versions are supported:
 
-* `^5.3`
-* `^6.3`
 * `^7.3`
 * `^8.0`
 

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "type": "neos-package",
     "license": "MIT",
     "require": {
-        "php": "^7.2 || ^8.0",
-        "neos/flow": "^5.3 || ^6.3 || ^7.3.6 || ^8.0.4",
+        "php": "^7.3 || ^8.0",
+        "neos/flow": "^7.3.6 || ^8.0.4",
         "sentry/sdk": "^3.1"
     },
     "autoload": {


### PR DESCRIPTION
The AbstractExceptionHandler is no longer compatible and tests
are not run as the phpunit.xml.dist file cannot be parsed on
old phpunit versions.