### PR TITLE
BUGFIX: Add default DSN from env var

### DIFF
--- a/Configuration/Settings.Dsn.yaml
+++ b/Configuration/Settings.Dsn.yaml
@@ -1,3 +1,3 @@
 Netlogix:
   Sentry:
-    dsn: ''
+    dsn: '%env:SENTRY_DSN%'


### PR DESCRIPTION
Using an env var instead of an empty string allows for a lot easier deployment scenarios, which is why there are already some env vars in use in this project.

A sentry integration without DSN is invalid. So using a potentially empty env var here is equally bad as using an empty string as default from an "ready to go" standpoint. This allows for treating this as bugfix.

see #24