### PR TITLE
BUGFIX: handle nullable stacktraces

### DIFF
--- a/Classes/Integration/NetlogixIntegration.php
+++ b/Classes/Integration/NetlogixIntegration.php
@@ -83,7 +83,9 @@ final class NetlogixIntegration implements IntegrationInterface
         $rewrittenExceptions = array_map(
             function ($exception) {
                 $stacktrace = $exception->getStacktrace();
-                $exception->setStacktrace(self::rewriteStacktraceAndFlagInApp($stacktrace));
+                if ($stacktrace !== null) {
+                    $exception->setStacktrace(self::rewriteStacktraceAndFlagInApp($stacktrace));
+                }
                 return $exception;
             },
             $event->getExceptions()


### PR DESCRIPTION
Stacktraces of an exception are nullable by interface.

Both `setStacktrace` and `rewriteStacktraceAndFlagInApp` only accept a `Stacktrace` instance and a TypeError is thrown, if no stacktrace is available.