### PR TITLE
feat: Enhanced variable scrubbing and context vars

### DIFF
--- a/Classes/Command/SentryCommandController.php
+++ b/Classes/Command/SentryCommandController.php
@@ -45,6 +45,11 @@ class SentryCommandController extends CommandController
 
         $this->outputLine();
 
+        $this->outputLine('Scope Extra:');
+        \Neos\Flow\var_dump($this->scopeProvider->collectContexts());
+
+        $this->outputLine();
+
         $this->outputLine('Scope Release:');
         \Neos\Flow\var_dump($this->scopeProvider->collectRelease());
 

--- a/Classes/Integration/NetlogixIntegration.php
+++ b/Classes/Integration/NetlogixIntegration.php
@@ -160,7 +160,7 @@ final class NetlogixIntegration implements IntegrationInterface
         return true;
     }
 
-    private static function scrubVariablesFromFrame($traceFunction, $frameVariables): array
+    private static function scrubVariablesFromFrame(string $traceFunction, array $frameVariables): array
     {
         if (!$frameVariables) {
             return $frameVariables;

--- a/Classes/Integration/NetlogixIntegration.php
+++ b/Classes/Integration/NetlogixIntegration.php
@@ -106,16 +106,17 @@ final class NetlogixIntegration implements IntegrationInterface
     private static function rewriteStacktraceAndFlagInApp(Stacktrace $stacktrace): Stacktrace
     {
         $frames = array_map(function ($frame) {
+            $functionName = self::replaceProxyClassName($frame->getFunctionName());
             $classPathAndFilename = self::getOriginalClassPathAndFilename($frame->getFile());
             return new Frame(
-                self::replaceProxyClassName($frame->getFunctionName()),
+                $functionName,
                 $classPathAndFilename,
                 $frame->getLine(),
                 self::replaceProxyClassName($frame->getRawFunctionName()),
                 $frame->getAbsoluteFilePath()
                     ? Files::concatenatePaths([FLOW_PATH_ROOT, trim($classPathAndFilename, '/')])
                     : null,
-                $frame->getVars(),
+                self::scrubVariablesFromFrame((string)$functionName, $frame->getVars()),
                 self::isInApp($classPathAndFilename)
             );
         }, $stacktrace->getFrames());
@@ -159,6 +160,51 @@ final class NetlogixIntegration implements IntegrationInterface
         return true;
     }
 
+    private static function scrubVariablesFromFrame($traceFunction, $frameVariables): array
+    {
+        if (!$frameVariables) {
+            return $frameVariables;
+        }
+        assert(is_array($frameVariables));
+
+        $config = Bootstrap::$staticObjectManager
+            ->get(ConfigurationManager::class)
+            ->getConfiguration(
+            ConfigurationManager::CONFIGURATION_TYPE_SETTINGS,
+            'Netlogix.Sentry.variableScrubbing'
+        ) ?? [];
+
+        $scrubbing = (bool)($config['scrubbing'] ?? false);
+        if (!$scrubbing) {
+            return $frameVariables;
+        }
+
+        $keep = $config['keepFromScrubbing'] ?? [];
+        if (!$keep) {
+            return [];
+        }
+
+        $result = [];
+        $traceFunction = str_replace('_Original::', '::', $traceFunction);
+        foreach ($keep as $keepConfig) {
+            try {
+                ['className' => $className, 'methodName' => $methodName, 'arguments' => $arguments] = $keepConfig;
+                $configFunction = $className . '::' . $methodName;
+                if ($configFunction !== $traceFunction) {
+                    continue;
+                }
+                foreach ($arguments as $argumentName) {
+                    $result[$argumentName] = $frameVariables[$argumentName] ?? '👻';
+                }
+
+            } catch (\Exception $e) {
+            }
+
+        }
+
+        return $result;
+    }
+
     private static function configureScopeForEvent(Event $event, EventHint $hint): void
     {
         try {
@@ -170,6 +216,9 @@ final class NetlogixIntegration implements IntegrationInterface
             $configureEvent = function () use ($event, $scopeProvider) {
                 $event->setEnvironment($scopeProvider->collectEnvironment());
                 $event->setExtra($scopeProvider->collectExtra());
+                foreach ($scopeProvider->collectContexts() as $key => $value) {
+                    $event->setContext($key, $value);
+                }
                 $event->setRelease($scopeProvider->collectRelease());
                 $event->setTags($scopeProvider->collectTags());
                 $userData = $scopeProvider->collectUser();

--- a/Classes/Scope/Context/ContextProvider.php
+++ b/Classes/Scope/Context/ContextProvider.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Netlogix\Sentry\Scope\Context;
+
+interface ContextProvider
+{
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getContexts(): array;
+
+}

--- a/Classes/Scope/Extra/VariablesFromStackProvider.php
+++ b/Classes/Scope/Extra/VariablesFromStackProvider.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\Sentry\Scope\Extra;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Reflection\MethodReflection;
+use Neos\Utility\ObjectAccess;
+use Netlogix\Sentry\Scope\ScopeProvider;
+use Sentry\SentrySdk;
+use Sentry\Serializer\RepresentationSerializer;
+use Throwable;
+use Traversable;
+
+use function array_combine;
+use function array_filter;
+use function class_exists;
+use function is_string;
+use function iterator_to_array;
+use function json_encode;
+use function method_exists;
+
+/**
+ * @Flow\Scope("singleton")
+ */
+final class VariablesFromStackProvider implements ExtraProvider
+{
+    private const FUNCTION_PATTERN = '%s::%s()';
+
+    /**
+     * @var ScopeProvider
+     * @Flow\Inject
+     */
+    protected $scopeProvider;
+
+    /**
+     * @var array
+     * @Flow\InjectConfiguration(package="Netlogix.Sentry", path="variableScrubbing.contextDetails")
+     */
+    protected array $settings = [];
+
+    public function getExtra(): array
+    {
+        $result = iterator_to_array($this->collectDataFromTraversables(), false);
+        if ($result) {
+            return ['Method Arguments' => $result];
+        } else {
+            return [];
+        }
+    }
+
+    private function collectDataFromTraversables(): Traversable
+    {
+        $throwable = $this->scopeProvider->getCurrentThrowable();
+        while ($throwable instanceof Throwable) {
+            yield from $this->collectDataFromTraces($throwable);
+            $throwable = $throwable->getPrevious();
+        }
+    }
+
+    private function collectDataFromTraces(Throwable $throwable): Traversable
+    {
+        $traces = $throwable->getTrace();
+        foreach ($traces as $trace) {
+            yield from $this->collectDataFromTrace($trace);
+        }
+    }
+
+    private function collectDataFromTrace(array $trace): Traversable
+    {
+        $traceFunction = self::callablePattern($trace['class'] ?? '', $trace['function'] ?? '');
+
+        $settings = iterator_to_array($this->getSettings(), false);
+        foreach ($settings as ['className' => $className, 'methodName' => $methodName, 'argumentPaths' => $argumentPaths]) {
+            $configFunction = self::callablePattern($className, $methodName);
+            if ($traceFunction !== $configFunction) {
+                continue;
+            }
+            $values = [];
+            foreach ($argumentPaths as $argumentPathName => $argumentPathLookup) {
+                try {
+                    $values[$argumentPathName] = $this->representationSerialize(
+                        ObjectAccess::getPropertyPath($trace['args'], $argumentPathLookup)
+                    );
+                } catch (Throwable $t) {
+                    $values[$argumentPathName] = '👻';
+                }
+            }
+            yield [$configFunction => $values];
+        }
+    }
+
+    private function representationSerialize($value)
+    {
+        static $representationSerialize;
+
+        if (!$representationSerialize) {
+            $client = SentrySdk::getCurrentHub()->getClient();
+            if ($client) {
+                $serializer = new RepresentationSerializer($client->getOptions());
+                $representationSerialize = function($value) use ($serializer) {
+                    return $serializer->representationSerialize($value);
+                };
+            } else {
+                $representationSerialize = function($value) {
+                    return json_encode($value);
+                };
+            }
+        }
+
+        return $representationSerialize($value);
+    }
+
+    private function getSettings(): Traversable
+    {
+        foreach ($this->settings as $config) {
+            $className = $config['className'] ?? null;
+            if (!$className || !class_exists($className)) {
+                continue;
+            }
+
+            $methodName = $config['methodName'] ?? null;
+            if (!$methodName || !method_exists($className, $methodName)) {
+                continue;
+            }
+
+            if (!is_array($config['arguments'])) {
+                continue;
+            }
+
+            $argumentPaths = array_filter($config['arguments'] ?? [], function ($argumentPath) {
+                return is_string($argumentPath) && $argumentPath;
+            });
+            $argumentPaths = array_combine($argumentPaths, $argumentPaths);
+
+            $reflection = new MethodReflection($className, $methodName);
+            foreach ($reflection->getParameters() as $parameter) {
+                $search = sprintf('/^%s./', $parameter->getName());
+                $replace = sprintf('%d.', $parameter->getPosition());
+                $argumentPaths = preg_replace($search, $replace, $argumentPaths);
+            }
+
+            yield [
+                'className' => $className,
+                'methodName' => $methodName,
+                'argumentPaths' => $argumentPaths
+            ];
+            yield [
+                'className' => $className . '_Original',
+                'methodName' => $methodName,
+                'argumentPaths' => $argumentPaths
+            ];
+        }
+    }
+
+    private function callablePattern(string $className, string $methodName): string
+    {
+        return sprintf(self::FUNCTION_PATTERN, $className, $methodName);
+    }
+}

--- a/Classes/Scope/ScopeProvider.php
+++ b/Classes/Scope/ScopeProvider.php
@@ -7,6 +7,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 use Neos\Utility\PositionalArraySorter;
 use Netlogix\Sentry\Exception\InvalidProviderType;
+use Netlogix\Sentry\Scope\Context\ContextProvider;
 use Netlogix\Sentry\Scope\Environment\EnvironmentProvider;
 use Netlogix\Sentry\Scope\Extra\ExtraProvider;
 use Netlogix\Sentry\Scope\Release\ReleaseProvider;
@@ -24,6 +25,7 @@ class ScopeProvider
 
     private const SCOPE_ENVIRONMENT = 'environment';
     private const SCOPE_EXTRA = 'extra';
+    private const SCOPE_CONTEXTS = 'contexts';
     private const SCOPE_RELEASE = 'release';
     private const SCOPE_TAGS = 'tags';
     private const SCOPE_USER = 'user';
@@ -31,6 +33,7 @@ class ScopeProvider
     private const SCOPE_TYPE_MAPPING = [
         self::SCOPE_ENVIRONMENT => EnvironmentProvider::class,
         self::SCOPE_EXTRA => ExtraProvider::class,
+        self::SCOPE_CONTEXTS => ContextProvider::class,
         self::SCOPE_RELEASE => ReleaseProvider::class,
         self::SCOPE_TAGS => TagProvider::class,
         self::SCOPE_USER => UserProvider::class,
@@ -52,6 +55,7 @@ class ScopeProvider
     protected $providers = [
         self::SCOPE_ENVIRONMENT => [],
         self::SCOPE_EXTRA => [],
+        self::SCOPE_CONTEXTS => [],
         self::SCOPE_RELEASE => [],
         self::SCOPE_TAGS => [],
         self::SCOPE_USER => [],
@@ -96,6 +100,19 @@ class ScopeProvider
         }
 
         return $extra;
+    }
+
+    public function collectContexts(): array
+    {
+        $contexts = [];
+
+        foreach ($this->providers[self::SCOPE_CONTEXTS] as $provider) {
+            assert($provider instanceof ContextProvider);
+
+            $extra = array_merge_recursive($extra, $provider->getContexts());
+        }
+
+        return $contexts;
     }
 
     public function collectRelease(): ?string

--- a/Configuration/Settings.Providers.yaml
+++ b/Configuration/Settings.Providers.yaml
@@ -8,6 +8,7 @@ Netlogix:
 
       extra:
         'Netlogix\Sentry\Scope\Extra\ReferenceCodeProvider': true
+        'Netlogix\Sentry\Scope\Extra\VariablesFromStackProvider': true
 
       release:
         # See Configuration/Settings.Release.yaml for settings

--- a/Configuration/Settings.VariableScrubbing.yaml
+++ b/Configuration/Settings.VariableScrubbing.yaml
@@ -1,0 +1,38 @@
+Netlogix:
+  Sentry:
+
+    variableScrubbing:
+
+      scrubbing: true
+
+      keepFromScrubbing:
+
+        'Neos\ContentRepository\Search\Indexer\NodeIndexingManager::indexNode()':
+          className: 'Neos\ContentRepository\Search\Indexer\NodeIndexingManager'
+          methodName: 'indexNode'
+          arguments:
+            - 'node'
+
+        'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Indexer\NodeIndexer::indexNode()':
+          className: 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Indexer\NodeIndexer'
+          methodName: 'indexNode'
+          arguments:
+            - 'node'
+
+      contextDetails:
+
+        'Neos\ContentRepository\Search\Indexer\NodeIndexingManager::indexNode()':
+          className: 'Neos\ContentRepository\Search\Indexer\NodeIndexingManager'
+          methodName: 'indexNode'
+          arguments:
+            - 'node.path'
+            - 'node.identifier'
+            - 'node.name'
+
+        'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Indexer\NodeIndexer::indexNode()':
+          className: 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Indexer\NodeIndexer'
+          methodName: 'indexNode'
+          arguments:
+            - 'node.path'
+            - 'node.identifier'
+            - 'node.name'


### PR DESCRIPTION
Scrub frame variables manually in case scrubbing isn't already done by zend.exception_ignore_args.

This allows for individual per-frame decissions to either drop certain variables or keep them. It doesn't change, however, how frame variables are transported to Sentry, which usually is very none-descriptive due to how Sentry handles variable repreesntation.

To add more details to variables, specific frame variables can be analyzed and copied from frames to the event context befor being potentially scrubbed and stringified.