### PR TITLE
fix: Don't rewrite POST payload during compile time

### DIFF
--- a/Classes/Integration/NetlogixIntegration.php
+++ b/Classes/Integration/NetlogixIntegration.php
@@ -248,6 +248,10 @@ final class NetlogixIntegration implements IntegrationInterface
      */
     public static function encryptPostBody(Event $event, EventHint $hint): Event
     {
+        if (Bootstrap::$staticObjectManager instanceof CompileTimeObjectManager) {
+            return $event;
+        }
+
         $encryptedPayload = Bootstrap::$staticObjectManager->get(\Netlogix\Sentry\EventProcessor\EncryptedPayload::class);
         return $encryptedPayload->rewriteEvent($event, $hint);
     }


### PR DESCRIPTION
The EncryptedPayload class might not be available and compiling doesn't happen in a web request anyway