### PR TITLE
fix: Ignore boolean flags or args without explicit = sign in cron monitoring

### DIFF
--- a/Classes/Aspects/CronMonitorAspect.php
+++ b/Classes/Aspects/CronMonitorAspect.php
@@ -73,8 +73,11 @@ class CronMonitorAspect
 
         $commandLineArguments = [];
         foreach ($commandLine as $rawCommandLineArgument) {
-            if (strpos($rawCommandLineArgument, '-') !== 0) {
+            if (!str_starts_with($rawCommandLineArgument, '-')) {
                 continue; // Skip non-argument parts of the command line
+            }
+            if (!str_contains($rawCommandLineArgument, '=')) {
+                continue; // Skip bool flags or args without explicit equal sign
             }
 
             list ($name, $value) = explode('=', $rawCommandLineArgument, 2);

--- a/README.md
+++ b/README.md
@@ -383,12 +383,14 @@ Add cron monitoring slug and schedule to your command parameters:
 >      --cron-monitor-max-time=CRON-MONITOR-MAX-TIME          if command should be monitored then pass cron monitor max execution time
 >      --cron-monitor-check-margin=CRON-MONITOR-CHECK-MARGIN  if command should be monitored then pass cron monitor check margin
 
+**Note: The equal sign between a parameter name and value is mandatory!**
+
 example usage in crontab
 ```
-0 0 * * *   user    ./flow sentry:test --cron-monitor-slug=sentry_test_midnight --cron-monitor-schedule "0 0 * * *"
+0 0 * * *   user    ./flow sentry:test --cron-monitor-slug=sentry_test_midnight --cron-monitor-schedule="0 0 * * *"
 ```
 
-Optionally you can also set max run time and check margin (see https://docs.sentry.io/platforms/php/crons/)
+Optionally, you can also set max run time and check margin (see https://docs.sentry.io/platforms/php/crons/)
 ```
-0 0 * * *   user    ./flow sentry:test --cron-monitor-slug=sentry_test_midnight --cron-monitor-schedule "0 0 * * *" --cron-monitor-max-time=5 --cron-monitor-check-margin=2
+0 0 * * *   user    ./flow sentry:test --cron-monitor-slug=sentry_test_midnight --cron-monitor-schedule="0 0 * * *" --cron-monitor-max-time=5 --cron-monitor-check-margin=2
 ```


### PR DESCRIPTION
Args may be passed without explicit equal sign, e.g.:
```
./flow scheduler:pollforincomingjobs --groupName default
```

Those args would break the aspect, causing flow to throw an exception