### PR TITLE
feat: Add provider to set additional sentry client options

### DIFF
--- a/Classes/ClientOptions/BaseClientOptionsProvider.php
+++ b/Classes/ClientOptions/BaseClientOptionsProvider.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\Sentry\ClientOptions;
+
+use Neos\Flow\Annotations as Flow;
+use Netlogix\Sentry\Integration\NetlogixIntegration;
+
+/**
+ * Sets up the basic options for the Sentry client.
+ * To add additional options, you can extend this class and register it as
+ * implementation for the {@see ClientOptionsProviderInterface}.
+ */
+class BaseClientOptionsProvider implements ClientOptionsProviderInterface
+{
+    /**
+     * @Flow\InjectConfiguration(package="Netlogix.Sentry", path="dsn")
+     * @var string|null
+     */
+    protected $dsn;
+
+    /**
+     * @Flow\InjectConfiguration(package="Netlogix.Sentry", path="inAppExclude")
+     * @var string[]|null
+     */
+    protected $inAppExclude;
+
+    public function getClientOptions(): array
+    {
+        $dsn = $this->dsn;
+        $inAppExclude = $this->inAppExclude;
+
+        return [
+            'dsn' => $dsn,
+            'integrations' => [
+                new NetlogixIntegration($inAppExclude ?? []),
+            ],
+        ];
+    }
+}

--- a/Classes/ClientOptions/ClientOptionsProviderInterface.php
+++ b/Classes/ClientOptions/ClientOptionsProviderInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netlogix\Sentry\ClientOptions;
+
+/**
+ * Interface to provide options to the Sentry client.
+ * You may want to extend the {@see BaseClientOptionsProvider} instead.
+ */
+interface ClientOptionsProviderInterface
+{
+    /**
+     * Provide the options used to initialize the Sentry client.
+     * @return array<string, mixed>
+     */
+    public function getClientOptions(): array;
+}

--- a/README.md
+++ b/README.md
@@ -394,3 +394,28 @@ Optionally, you can also set max run time and check margin (see https://docs.sen
 ```
 0 0 * * *   user    ./flow sentry:test --cron-monitor-slug=sentry_test_midnight --cron-monitor-schedule="0 0 * * *" --cron-monitor-max-time=5 --cron-monitor-check-margin=2
 ```
+
+## Providing additional Sentry options
+
+To specify additional options for the Sentry client, passed to the `init()` function, you can implement the `ClientOptionsProviderInterface`.
+You may want to extend the `BaseClientOptionsProvider`, which configures the default options.
+```php
+class MyClientOptionsProvider extends BaseClientOptionsProvider
+{
+    public function getClientOptions(): array
+    {
+        return [
+            ...parent::getClientOptions(),
+            'additional_option' => '...',
+        ];
+    }
+}
+```
+
+Then you need to configure your class in the `Objects.yaml`:
+```yaml
+Netlogix\Sentry\ClientOptions\ClientOptionsProviderInterface:
+  className: My\Package\MyClientOptionsProvider
+```
+
+As the client is initialized in the boot sequence, you may need to flush caches.


### PR DESCRIPTION
Introduces an interface to get client options for sentry init and a base class to initialize sentry as before.

To use the object-management for getting an overwritten InitOptionsProvider, I had to move the initialization to a later step in the bootstrap sequence. It will now probably fail to capture errors earlier. Maybe there is a different step we could use or maybe it would be reasonable to just initialize with the base provider as before and initialize it again later?