### PR TITLE
fix: Expect quoted string representations

### DIFF
--- a/.github/workflows/functionaltests.yml
+++ b/.github/workflows/functionaltests.yml
@@ -11,12 +11,12 @@ jobs:
       fail-fast: false
       matrix:
         php-version: [ 8.0, 8.1, 8.2, 8.3 ]
-        flow-version: [ 8.0, 9.0 ]
+        flow-version: [ 8.0, '9.0.0-beta' ]
         exclude:
           - php-version: 8.0
-            flow-version: 9.0
+            flow-version: '9.0.0-beta'
           - php-version: 8.1
-            flow-version: 9.0
+            flow-version: '9.0.0-beta'
 
     env:
       APP_ENV: true
@@ -30,27 +30,30 @@ jobs:
           extensions: mbstring, xml, json, zlib, iconv, intl, pdo_sqlite
           ini-values: opcache.fast_shutdown=0
 
-      - name: "[1/5] Create composer project - Cache composer dependencies"
-        uses: actions/cache@v4
-        with:
-          path: ~/.composer/cache
-          key: php-${{ matrix.php-version }}-flow-${{ matrix.flow-version }}-composer-${{ hashFiles('composer.json') }}
-          restore-keys: |
-            php-${{ matrix.php-version }}-flow-${{ matrix.flow-version }}-composer-
-            php-${{ matrix.php-version }}-flow-
-
-      - name: "[2/5] Create composer project - No install"
+      - name: "Create composer project - No install"
         run: composer create-project neos/flow-base-distribution ${{ env.FLOW_DIST_FOLDER }} --prefer-dist --no-progress --no-install "^${{ matrix.flow-version }}"
 
-      - name: "[3/5] Allow neos composer plugin"
+      - name: "Allow neos composer plugin"
         run: composer config --no-plugins allow-plugins.neos/composer-plugin true
         working-directory: ${{ env.FLOW_DIST_FOLDER }}
 
-      - name: "[4/5] Create composer project  - Require behat in compatible version"
+      - name: "Create composer project  - Require behat in compatible version"
         run: composer require --dev --no-update "neos/behat:@dev"
         working-directory: ${{ env.FLOW_DIST_FOLDER }}
 
-      - name: "[5/5] Create composer project - Install project"
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+        working-directory: ${{ env.FLOW_DIST_FOLDER }}
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: "Create composer project - Install project"
         run: composer install
         working-directory: ${{ env.FLOW_DIST_FOLDER }}
 

--- a/.github/workflows/functionaltests.yml
+++ b/.github/workflows/functionaltests.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version: [ 8.3, 8.4, 8.5 ]
-        flow-version: [ 8.3, 9.1 ]
+        flow-version: [ "~8.3.0", "~9.0.0" ]
 
     env:
       APP_ENV: true
@@ -26,7 +26,7 @@ jobs:
           ini-values: opcache.fast_shutdown=0
 
       - name: "Create composer project - No install"
-        run: composer create-project neos/flow-base-distribution ${{ env.FLOW_DIST_FOLDER }} --prefer-dist --no-progress --no-install "~${{ matrix.flow-version }}"
+        run: composer create-project --prefer-dist --no-progress --no-install neos/flow-base-distribution ${{ env.FLOW_DIST_FOLDER }} "${{ matrix.flow-version }}"
 
       - name: "Allow neos composer plugin"
         run: composer config --no-plugins allow-plugins.neos/composer-plugin true

--- a/.github/workflows/functionaltests.yml
+++ b/.github/workflows/functionaltests.yml
@@ -10,13 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ 8.0, 8.1, 8.2, 8.3 ]
-        flow-version: [ 8.0, '9.0.0-beta' ]
-        exclude:
-          - php-version: 8.0
-            flow-version: '9.0.0-beta'
-          - php-version: 8.1
-            flow-version: '9.0.0-beta'
+        php-version: [ 8.3, 8.4, 8.5 ]
+        flow-version: [ 8.3, 9.1 ]
 
     env:
       APP_ENV: true
@@ -31,7 +26,7 @@ jobs:
           ini-values: opcache.fast_shutdown=0
 
       - name: "Create composer project - No install"
-        run: composer create-project neos/flow-base-distribution ${{ env.FLOW_DIST_FOLDER }} --prefer-dist --no-progress --no-install "^${{ matrix.flow-version }}"
+        run: composer create-project neos/flow-base-distribution ${{ env.FLOW_DIST_FOLDER }} --prefer-dist --no-progress --no-install "~${{ matrix.flow-version }}"
 
       - name: "Allow neos composer plugin"
         run: composer config --no-plugins allow-plugins.neos/composer-plugin true

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -10,13 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ 8.0, 8.1, 8.2, 8.3 ]
-        flow-version: [ 8.3, '9.0.0-beta' ]
-        exclude:
-          - php-version: 8.0
-            flow-version: '9.0.0-beta'
-          - php-version: 8.1
-            flow-version: '9.0.0-beta'
+        php-version: [ 8.3, 8.4, 8.5 ]
+        flow-version: [ 8.3, 9.1 ]
 
     env:
       APP_ENV: true
@@ -31,7 +26,7 @@ jobs:
           ini-values: opcache.fast_shutdown=0
 
       - name: "Create composer project - No install"
-        run: composer create-project neos/flow-base-distribution ${{ env.FLOW_DIST_FOLDER }} --prefer-dist --no-progress --no-install "^${{ matrix.flow-version }}"
+        run: composer create-project neos/flow-base-distribution ${{ env.FLOW_DIST_FOLDER }} --prefer-dist --no-progress --no-install "~${{ matrix.flow-version }}"
 
       - name: "Allow neos composer plugin"
         run: composer config --no-plugins allow-plugins.neos/composer-plugin true

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -11,12 +11,12 @@ jobs:
       fail-fast: false
       matrix:
         php-version: [ 8.0, 8.1, 8.2, 8.3 ]
-        flow-version: [ 8.3, 9.0 ]
+        flow-version: [ 8.3, '9.0.0-beta' ]
         exclude:
           - php-version: 8.0
-            flow-version: 9.0
+            flow-version: '9.0.0-beta'
           - php-version: 8.1
-            flow-version: 9.0
+            flow-version: '9.0.0-beta'
 
     env:
       APP_ENV: true
@@ -30,27 +30,30 @@ jobs:
           extensions: mbstring, xml, json, zlib, iconv, intl, pdo_sqlite
           ini-values: opcache.fast_shutdown=0
 
-      - name: "[1/5] Create composer project - Cache composer dependencies"
-        uses: actions/cache@v4
-        with:
-          path: ~/.composer/cache
-          key: php-${{ matrix.php-version }}-flow-${{ matrix.flow-version }}-composer-${{ hashFiles('composer.json') }}
-          restore-keys: |
-            php-${{ matrix.php-version }}-flow-${{ matrix.flow-version }}-composer-
-            php-${{ matrix.php-version }}-flow-
-
-      - name: "[2/5] Create composer project - No install"
+      - name: "Create composer project - No install"
         run: composer create-project neos/flow-base-distribution ${{ env.FLOW_DIST_FOLDER }} --prefer-dist --no-progress --no-install "^${{ matrix.flow-version }}"
 
-      - name: "[3/5] Allow neos composer plugin"
+      - name: "Allow neos composer plugin"
         run: composer config --no-plugins allow-plugins.neos/composer-plugin true
         working-directory: ${{ env.FLOW_DIST_FOLDER }}
 
-      - name: "[4/5] Create composer project  - Require behat in compatible version"
+      - name: "Create composer project  - Require behat in compatible version"
         run: composer require --dev --no-update "neos/behat:@dev"
         working-directory: ${{ env.FLOW_DIST_FOLDER }}
 
-      - name: "[5/5] Create composer project - Install project"
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+        working-directory: ${{ env.FLOW_DIST_FOLDER }}
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: "Create composer project - Install project"
         run: composer install
         working-directory: ${{ env.FLOW_DIST_FOLDER }}
 

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version: [ 8.3, 8.4, 8.5 ]
-        flow-version: [ 8.3, 9.1 ]
+        flow-version: [ "~8.3.0", "~9.0.0" ]
 
     env:
       APP_ENV: true
@@ -26,7 +26,7 @@ jobs:
           ini-values: opcache.fast_shutdown=0
 
       - name: "Create composer project - No install"
-        run: composer create-project neos/flow-base-distribution ${{ env.FLOW_DIST_FOLDER }} --prefer-dist --no-progress --no-install "~${{ matrix.flow-version }}"
+        run: composer create-project --prefer-dist --no-progress --no-install neos/flow-base-distribution ${{ env.FLOW_DIST_FOLDER }} "${{ matrix.flow-version }}"
 
       - name: "Allow neos composer plugin"
         run: composer config --no-plugins allow-plugins.neos/composer-plugin true

--- a/Tests/Unit/Scope/Extra/VariablesFromStackProviderTest.php
+++ b/Tests/Unit/Scope/Extra/VariablesFromStackProviderTest.php
@@ -33,7 +33,7 @@ class VariablesFromStackProviderTest extends UnitTestCase
         self::assertEquals([
             [
                 'foo::bar()' => [
-                    'baz' => 'some value'
+                    'baz' => '"some value"'
                 ]
             ]
         ], $result);
@@ -65,8 +65,8 @@ class VariablesFromStackProviderTest extends UnitTestCase
         self::assertEquals([
             [
                 'foo::bar()' => [
-                    'baz.name' => 'Stephan',
-                    'baz.gender' => 'male',
+                    'baz.name' => '"Stephan"',
+                    'baz.gender' => '"male"',
                 ]
             ]
         ], $result);


### PR DESCRIPTION
There's a difference between `null` and `"null"`, which is prperly handled by the lib but not expected in the most recent tests.